### PR TITLE
Add `py.typed`

### DIFF
--- a/fsdag/py.typed
+++ b/fsdag/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561. The mypy package uses inline types.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 
 dependencies = []
 
-license = {text = "MIT License"}
+license = { text = "MIT License" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -33,6 +33,9 @@ repository = "https://github.com/mristin/fsdag"
 [tool.setuptools.packages.find]
 include = ["fsdag"]
 exclude = ["precommit.py"]
+
+[tool.setuptools.package-data]
+"fsdag" = ["py.typed"]
 
 # Development dependencies
 [tool]
@@ -62,3 +65,4 @@ dev = [
     "pylint==3.2.7",
     "coverage==7.6.1"
 ]
+


### PR DESCRIPTION
We add the `py.typed` file to the package, so that the clients can use mypy with it.